### PR TITLE
Bugfix: Npm publish auth error

### DIFF
--- a/.npmrc
+++ b/.npmrc
@@ -1,0 +1,1 @@
+@aacn_org:registry=https://registry.npmjs.org/


### PR DESCRIPTION
Add an npmrc config file, that potentially fixes the authentication error when trying to sign in to to npm