### PR TITLE
Feature: Add function to reset widget

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -28,3 +28,8 @@
 
 ### v1.2.3
 - Adjust nextjs hydration for style tags
+
+### v1.3.0
+- Add function that allows to reset the current widget. This is useful if a form is submitted, 
+but the server returns an error, so the user is forced to adjust their information. As this often
+doesn't reset the page, the widget isn't automatically resetted. When submitting the form again, this would cause an error.

--- a/package.json
+++ b/package.json
@@ -9,7 +9,7 @@
   "publishConfig": {
     "access": "public"
   },
-  "version": "1.2.3",
+  "version": "1.3.0",
   "license": "MIT",
   "private": false,
   "engines": {

--- a/playground/src/components/index.tsx
+++ b/playground/src/components/index.tsx
@@ -53,6 +53,7 @@ const Example: FC = () => {
           <React.Fragment>
             <p className="text-xl text-black absolute top-10">solved!</p>
             <button id="submit-btn" className="p-5 bg-yellow-600">Submit</button>
+            <button className="p-5 bg-yellow-600" onClick={() => captchaManager.resetWidget()}>Reset widget</button>
           </React.Fragment>
         )}
         {captchaManager.captchaStatus.error !== null && (


### PR DESCRIPTION
## Changelog
Add  a function that allows to reset the current widget. This is useful if a form is submitted, but the server returns an error, so the user is forced to adjust their information. As this often doesn't reset the page, the widget isn't automatically resetted. When submitting the form again, this would cause an error as the captcha was 'already solved'.